### PR TITLE
added .xxx files to .gitignore and started tracking it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+.project
+.classpath
+.settings/


### PR DESCRIPTION
I could not pull from team-quizki/quizki-backend with the following error...
```
error: The following untracked working tree files would be overwritten by merge:
	.gitignore
Please move or remove them before you can merge.
Aborting
jrdissermac@MacBook-Air:~/eclipse-workspace/quizki-backend[dev]$ gs
On branch dev
Your branch is up-to-date with 'origin/dev'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.classpath
	.gitignore
	.project
	.settings/
```
Added the .files to .gitignore and added .gitignore to the commit
The .gitignore file was either in the cloned repo or generated by Maven on the import, I think the latter.