### PR TITLE
Allow CORS preflight OPTIONS request to quizki-backend/verifyCredentials

### DIFF
--- a/src/main/java/com/haxwell/apps/quizki/_servletFilters/CorsFilter.java
+++ b/src/main/java/com/haxwell/apps/quizki/_servletFilters/CorsFilter.java
@@ -21,7 +21,7 @@ public class CorsFilter extends GenericFilterBean {
 		HttpServletResponse response = (HttpServletResponse) servletResponse;
 		HttpServletRequest req = (HttpServletRequest)servletRequest;
 
-		response.setHeader("Access-Control-Allow-Origin", "http://localhost:8100"); // was *
+		response.setHeader("Access-Control-Allow-Origin", "*"); // was http://localhost:8100
 		response.setHeader("Access-Control-Allow-Credentials", "true");
 		response.setHeader("Access-Control-Allow-Methods", "POST, GET, HEAD, OPTIONS, DELETE");
 		response.setHeader("Access-Control-Allow-Headers",

--- a/src/main/java/com/haxwell/apps/quizki/_servletFilters/CorsFilter.java
+++ b/src/main/java/com/haxwell/apps/quizki/_servletFilters/CorsFilter.java
@@ -21,7 +21,7 @@ public class CorsFilter extends GenericFilterBean {
 		HttpServletResponse response = (HttpServletResponse) servletResponse;
 		HttpServletRequest req = (HttpServletRequest)servletRequest;
 
-		response.setHeader("Access-Control-Allow-Origin", "*"); // was http://localhost:8100
+		response.setHeader("Access-Control-Allow-Origin", "http://localhost:4200"); // was http://localhost:8100
 		response.setHeader("Access-Control-Allow-Credentials", "true");
 		response.setHeader("Access-Control-Allow-Methods", "POST, GET, HEAD, OPTIONS, DELETE");
 		response.setHeader("Access-Control-Allow-Headers",

--- a/src/main/java/com/haxwell/apps/quizki/config/WebSecurityConfig.java
+++ b/src/main/java/com/haxwell/apps/quizki/config/WebSecurityConfig.java
@@ -55,7 +55,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     		.antMatchers(HttpMethod.POST, "/api/users").permitAll()
     		.antMatchers(HttpMethod.OPTIONS, "/api/verifyCredentials").permitAll()
 	    		// TODO: Handle login.. That should be open.
-	    		.antMatchers(HttpMethod.GET, "/api/verifyCredentials").permitAll()
+	    		.antMatchers(HttpMethod.GET, "/api/verifyCredentials").authenticated()
 	    		.antMatchers(HttpMethod.OPTIONS, "/api/verifyCredentials").permitAll()
 	    		.antMatchers("/api/**").authenticated()
                 .and() 

--- a/src/main/java/com/haxwell/apps/quizki/config/WebSecurityConfig.java
+++ b/src/main/java/com/haxwell/apps/quizki/config/WebSecurityConfig.java
@@ -54,6 +54,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         	.authorizeRequests()
 	    		.antMatchers(HttpMethod.POST, "/api/users").permitAll()
 	    		// TODO: Handle login.. That should be open.
+	    		.antMatchers(HttpMethod.GET, "/api/verifyCredentials").permitAll()
+	    		.antMatchers(HttpMethod.OPTIONS, "/api/verifyCredentials").permitAll()
 	    		.antMatchers("/api/**").authenticated()
                 .and() 
                 .logout()

--- a/src/main/java/com/haxwell/apps/quizki/controllers/VerifyCredentialsController.java
+++ b/src/main/java/com/haxwell/apps/quizki/controllers/VerifyCredentialsController.java
@@ -22,7 +22,7 @@ import com.haxwell.apps.quizki.repositories.UserRepository;
 //chrome preflight OPTIONS request is not handled by default in cors processor
 //https://stackoverflow.com/questions/38507370/cors-preflight-request-fails-due-to-a-standard-header
 
-@CrossOrigin(origins = "*")
+@CrossOrigin(origins = "http://localhost:4200")
 @RestController
 @RequestMapping(value = { "/api/verifyCredentials" })
 public class VerifyCredentialsController {
@@ -55,7 +55,6 @@ public class VerifyCredentialsController {
 	 * @return
 	 * @throws Exception
 	 */
-	//@GetMapping
 	@RequestMapping(method=RequestMethod.GET)
 	public User method1(HttpServletRequest request, Model model) throws Exception {
 		String[] arr = extractAndDecodeHeader(request.getHeader("Authorization"));
@@ -70,20 +69,7 @@ public class VerifyCredentialsController {
 		}
 		
 		return user != null ? user : null;
-	}
-	
-	/*
-	 * Return the cors header response to a preflight OPTIONS request
-	 */
-	
-	@RequestMapping(method=RequestMethod.OPTIONS)
-	public void corsHeaders(HttpServletResponse response) {
-	    response.addHeader("Access-Control-Allow-Origin", "*");
-	    response.addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-	    response.addHeader("Access-Control-Allow-Headers", "origin, content-type, accept, x-requested-with");
-	    response.addHeader("Access-Control-Max-Age", "3600");
-	}
-	
+	}	
 	
 	/**
 	 * Decodes the header into a username and password.

--- a/src/main/java/com/haxwell/apps/quizki/controllers/VerifyCredentialsController.java
+++ b/src/main/java/com/haxwell/apps/quizki/controllers/VerifyCredentialsController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -13,11 +14,15 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.haxwell.apps.quizki.entities.User;
 import com.haxwell.apps.quizki.repositories.UserRepository;
 
-@CrossOrigin
+//chrome preflight OPTIONS request is not handled by default in cors processor
+//https://stackoverflow.com/questions/38507370/cors-preflight-request-fails-due-to-a-standard-header
+
+@CrossOrigin(origins = "*")
 @RestController
 @RequestMapping(value = { "/api/verifyCredentials" })
 public class VerifyCredentialsController {
@@ -50,7 +55,8 @@ public class VerifyCredentialsController {
 	 * @return
 	 * @throws Exception
 	 */
-	@GetMapping
+	//@GetMapping
+	@RequestMapping(method=RequestMethod.GET)
 	public User method1(HttpServletRequest request, Model model) throws Exception {
 		String[] arr = extractAndDecodeHeader(request.getHeader("Authorization"));
 		
@@ -65,6 +71,19 @@ public class VerifyCredentialsController {
 		
 		return user != null ? user : null;
 	}
+	
+	/*
+	 * Return the cors header response to a preflight OPTIONS request
+	 */
+	
+	@RequestMapping(method=RequestMethod.OPTIONS)
+	public void corsHeaders(HttpServletResponse response) {
+	    response.addHeader("Access-Control-Allow-Origin", "*");
+	    response.addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+	    response.addHeader("Access-Control-Allow-Headers", "origin, content-type, accept, x-requested-with");
+	    response.addHeader("Access-Control-Max-Age", "3600");
+	}
+	
 	
 	/**
 	 * Decodes the header into a username and password.


### PR DESCRIPTION
I was able to get the basic "login" working after putting in these changes to handle to preflight request coming out of Chrome using the OPTIONS method. It was originally expecting an authorized user for that request and there wasn't any code to handle it. I have the frontend working in QuizkiTest and I was planning on just merging it into MASTER so it would get included in the first pull request BUT you merged that request about an hour before I finished!! Now I'm trying to figure out how to get another pull request to quizki-frontend from QuizkiTest...