### PR TITLE
added javax dependancy in pom.xml needed for java 9.x.y and higher releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
+		<dependency>
+		   <groupId>javax.xml.bind</groupId>
+		   <artifactId>jaxb-api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Added the javax dependancy to pom.xml file.  4 lines added at the end of the dependancy list. No other changes.

Tested successfully using:
java version "9.0.4"
Java(TM) SE Runtime Environment (build 9.0.4+11)
Java HotSpot(TM) 64-Bit Server VM (build 9.0.4+11, mixed mode)