### PR TITLE
Quizkey Backend issue# 33 Store password encoded for authentication

### DIFF
--- a/developer/Tests.postman_collection.json
+++ b/developer/Tests.postman_collection.json
@@ -1467,6 +1467,90 @@
 				}
 			},
 			"response": []
+		},
+		{
+			"name": "Create User w plaintext",
+			"request": {
+				"auth": {
+					"type": "noauth"
+				},
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"password\":\"plaintext\",\n\t\"name\":\"curly\",\n\t\"enabled\":1,\n\t\"roleId\":2,\n\t\"email\":\"curly@somewhere.com\",\n\t\"fullname\":\"Curly A Stooge III\"\n}"
+				},
+				"url": {
+					"raw": "http://localhost:8080/api/users",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"users"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Verify plaintext Credentials ",
+			"request": {
+				"auth": {
+					"type": "basic",
+					"basic": [
+						{
+							"key": "password",
+							"value": "plaintext",
+							"type": "string"
+						},
+						{
+							"key": "username",
+							"value": "curly",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "http://localhost:8080/api/verifyCredentials",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8080",
+					"path": [
+						"api",
+						"verifyCredentials"
+					]
+				}
+			},
+			"response": []
 		}
 	]
 }

--- a/src/main/java/com/haxwell/apps/quizki/services/UserServiceImpl.java
+++ b/src/main/java/com/haxwell/apps/quizki/services/UserServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import com.haxwell.apps.quizki.dtos.CreatedUserDTO;
@@ -25,12 +26,15 @@ public class UserServiceImpl implements UserService {
 	private UserRepository uRepo;
 	@Autowired
 	private UserRoleRepository uroleRepo;
+	@Autowired
+	private PasswordEncoder pwdEncode;
 	
 	
-	public UserServiceImpl(UserRepository uRepo, UserRoleRepository uroleRepo) {
+	public UserServiceImpl(UserRepository uRepo, UserRoleRepository uroleRepo, PasswordEncoder pwdEncode) {
 
 		this.uRepo = uRepo;
 		this.uroleRepo = uroleRepo;
+		this.pwdEncode = pwdEncode;
 	}
 	
 	
@@ -68,7 +72,7 @@ public class UserServiceImpl implements UserService {
 		user.setDemographic("default");				//TODO remove
 		user.setEnabled(1);							//TODO remove
 		user.setFullname(ucdto.getFullname());
-		user.setPassword(ucdto.getPassword());
+		user.setPassword(pwdEncode.encode(ucdto.getPassword()));
 		user.setId(null);
 		
 		User savedusr = uRepo.save(user);


### PR DESCRIPTION
Tested this with a couple of new Postman requests. Verify credentials responds with the edited User object using Postman's built in Authorization header generator. When creating the new user the password is sent in the DTO as plaintext BUT the frontend will need to encode the credentials for the Authorization Header.