### PR TITLE
Update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .classpath
 .settings/
 /bin/
+popq2db.bat

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .classpath
 .settings/
 /bin/
-popq2db.bat

--- a/README.md
+++ b/README.md
@@ -9,9 +9,15 @@ Here is what you need to do to get the project up and running on your local mach
 
 ### Dependencies
 To run the backend you will need the following tools
-* Oracle [Java](https://www.oracle.com/technetwork/java/javase/downloads/index.html) We've done light testing up through JDK9.
+* Oracle [Java](https://www.oracle.com/technetwork/java/javase/downloads/index.html) Use JDK8 as JDK11 currently does not work with quizki-backend.
 * Apache [Maven](https://maven.apache.org/) Check if you have it by typing `mvn -v`
 * Oracle [MySQL](https://www.mysql.com/)
+
+Other tools you will need if you are new to quizki-backend or to backend coding:
+* [GitHub account](https://github.com/)
+* [Git apps](https://git-scm.com/downloads)
+* [Postman API Developer](https://www.getpostman.com/)
+* [Eclipse IDE](https://www.eclipse.org/)
 
 #### Linux
 Install the dependencies (above) per the instructions for the given software package.
@@ -25,10 +31,20 @@ These dependencies can be installed using the [Homebrew](https://brew.sh/) packa
 * MySQL `$ brew install mysql`
 
 ### Installation
-You will need to clone this repository.
-  1. Clone this repository. `$ git clone https://github.com/team-quizki/quizki-backend.git`
-  2. Change to the quizki-backend directory. `$ cd quizki-backend`
-  3. Configure a remote for your fork. [GitHub Help](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2)
+You will need to fork the [team-quizki/quizki-backend repository](https://github.com/team-quizki/quizki-backend). Then clone your new fork to your local computer, and configure the cloned copy on your computer. You can follow these [instruction on Github](https://help.github.com/articles/fork-a-repo/). To summarize this instruction: 
+  1. On GitHub fork the [team-quizki/quizki-backend](https://github.com/team-quizki/quizki-backend) repository.
+  2. Using Git Bash or Git CMD clone your newly forked repository to your local computer:
+   `$ git clone https://github.com/<<UseYourGitHubHandleHere>>/quizki-backend.git`
+  3. Change to the quizki-backend directory. 
+  `$ cd quizki-backend`
+  4. Configure your local quizki-backend to use remote upstream. 
+  `$ git remote -v` to verify origin is set
+  `$ git remote add upstream hhttps://github.com/team-quizki/quizki-backend`  
+  `$ git remote -v` to verify upstream is set correctly
+  5. Confingure your user email and name if git was newly installed.
+  `$ git config --global user.email "yourEmail@example.com"` to set your email
+  `$ git config --global user.name "Your Name"` to set your name
+  
 
 ### Initializing the Database
 You will only need to do this the first time you run the backend.

--- a/README.md
+++ b/README.md
@@ -31,19 +31,27 @@ These dependencies can be installed using the [Homebrew](https://brew.sh/) packa
 * MySQL `$ brew install mysql`
 
 ### Installation
-You will need to fork the [team-quizki/quizki-backend repository](https://github.com/team-quizki/quizki-backend). Then clone your new fork to your local computer, and configure the cloned copy on your computer. You can follow these [instruction on Github](https://help.github.com/articles/fork-a-repo/). To summarize this instruction: 
-  1. On GitHub fork the [team-quizki/quizki-backend](https://github.com/team-quizki/quizki-backend) repository.
-  2. Using Git Bash or Git CMD clone your newly forked repository to your local computer:
-   `$ git clone https://github.com/<<UseYourGitHubHandleHere>>/quizki-backend.git`
-  3. Change to the quizki-backend directory. 
-  `$ cd quizki-backend`
-  4. Configure your local quizki-backend to use remote upstream. 
-  `$ git remote -v` to verify origin is set
-  `$ git remote add upstream hhttps://github.com/team-quizki/quizki-backend`  
-  `$ git remote -v` to verify upstream is set correctly
-  5. Confingure your user email and name if git was newly installed.
-  `$ git config --global user.email "yourEmail@example.com"` to set your email
-  `$ git config --global user.name "Your Name"` to set your name
+You will need to fork the [team-quizki/quizki-backend repository](https://github.com/team-quizki/quizki-backend), then clone your new fork to your local computer, and configure the cloned copy on your computer. You can follow these [instruction on Github](https://help.github.com/articles/fork-a-repo/). To summarize this instruction: 
+
+- On GitHub fork the [team-quizki/quizki-backend](https://github.com/team-quizki/quizki-backend) repository.
+
+- Using Git Bash or Git CMD clone your newly forked repository to your local computer:
+    `$ git clone https://github.com/<<UseYourGitHubHandleHere>>/quizki-backend.git`
+
+- Change to the quizki-backend directory. 
+    `$ cd quizki-backend`
+    
+- Configure your local quizki-backend to use remote upstream. 
+    `$ git remote add upstream hhttps://github.com/team-quizki/quizki-backend`  
+    
+- Verify upstream set correctly
+    `$ git remote -v`
+    
+- Configure your user email to prepare for commit
+    `$ git config --global user.email "yourEmail@example.com"` 
+    
+- Configure your name email to prepare for commit
+    `$ git config --global user.name "Your Name"` 
   
 
 ### Initializing the Database

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ You will need to fork the [team-quizki/quizki-backend repository](https://github
     
 - Check remote origin and upstream looks similar to the following.
     `$ git remote -v`
-    `origin  https://github.com/FrauDeborah/quizki-backend.git (fetch)`
-    `origin  https://github.com/FrauDeborah/quizki-backend.git (push)`
-    `upstream  https://github.com/team-quizki/quizki-backend.git (fetch)`
-    `upstream  https://github.com/team-quizki/quizki-backend.git (push)`
+    
+    > origin  https://github.com/FrauDeborah/quizki-backend.git (fetch)
+    > origin  https://github.com/FrauDeborah/quizki-backend.git (push)
+    > upstream  https://github.com/team-quizki/quizki-backend.git (fetch)
+    > upstream  https://github.com/team-quizki/quizki-backend.git (push)
    
     
 - Configure your user email to prepare for commit

--- a/README.md
+++ b/README.md
@@ -44,8 +44,13 @@ You will need to fork the [team-quizki/quizki-backend repository](https://github
 - Configure your local quizki-backend to use remote upstream. 
     `$ git remote add upstream hhttps://github.com/team-quizki/quizki-backend`  
     
-- Verify upstream set correctly
+- Check remote origin and upstream looks similar to the following.
     `$ git remote -v`
+    `origin  https://github.com/FrauDeborah/quizki-backend.git (fetch)`
+    `origin  https://github.com/FrauDeborah/quizki-backend.git (push)`
+    `upstream  https://github.com/team-quizki/quizki-backend.git (fetch)`
+    `upstream  https://github.com/team-quizki/quizki-backend.git (push)`
+   
     
 - Configure your user email to prepare for commit
     `$ git config --global user.email "yourEmail@example.com"` 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ You will need to fork the [team-quizki/quizki-backend repository](https://github
 - Check remote origin and upstream looks similar to the following.
     `$ git remote -v`
     
-    > origin  https://github.com/FrauDeborah/quizki-backend.git (fetch)
-    > origin  https://github.com/FrauDeborah/quizki-backend.git (push)
-    > upstream  https://github.com/team-quizki/quizki-backend.git (fetch)
-    > upstream  https://github.com/team-quizki/quizki-backend.git (push)
+> origin  https://github.com/FrauDeborah/quizki-backend.git (fetch)
+
+> origin  https://github.com/FrauDeborah/quizki-backend.git (push)
+
+> upstream  https://github.com/team-quizki/quizki-backend.git (fetch)
+
+> upstream  https://github.com/team-quizki/quizki-backend.git (push)
    
     
 - Configure your user email to prepare for commit


### PR DESCRIPTION
Johnathan @haxwell 

While setting up a new computer for the backend, I notice a few corrections for the README.md file.

1. Changed instructions to tell people to use JDK8 rather than JDK11. Removed reference to JDK 9 as JDK9 is no longer an options on Oracle.

2. Added tools to set up including links for

   - GitHub (perhaps over kill ;0)  
   - Git download 
   - Postman download 
   - Eclipse IDE download

3. Corrected the instructions for forking, cloning and configuring the backend. (Note: No small wonder the new people were having issues with setting up.)

Please review and push to dev and master if you agree. Or let me know if more changes are needed.

Thank you,

Deborah @FrauDeborah 
